### PR TITLE
feat: add medication record storage

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import NoteSummarizer from "./pages/NoteSummarizer";
 import About from "./pages/About";
 import Terms from "./pages/Terms";
 import Contact from "./pages/Contact";
+import MedicationHistory from "./pages/MedicationHistory";
 import ProtectedRoute from "./components/ProtectedRoute";
 import Navbar from './components/NavBar';
 import "./App.css";
@@ -67,6 +68,7 @@ function AppContent() {
             <Link to="/home">Home</Link> |{" "}
             <Link to="/submit">Submit Data</Link> |{" "}
             <Link to="/view">View Data</Link> |{" "}
+            <Link to="/medication-history">Medication History</Link> |{" "}
             <button
               onClick={() => setMenuOpen(!menuOpen)}
               style={{
@@ -123,6 +125,7 @@ function AppContent() {
                 <li onClick={() => handleNav("/home")}><HomeIcon size={16} /> Home</li>
                 <li onClick={() => handleNav("/submit")}><FilePlus size={16} /> Submit Data</li>
                 <li onClick={() => handleNav("/view")}><Eye size={16} /> View Data</li>
+                <li onClick={() => handleNav("/medication-history")}><FileText size={16} /> Medication History</li>
                 <li onClick={() => handleNav("/medical-history")}><FileText size={16} /> Medical History</li>
                 <li onClick={() => handleNav("/about")}><Info size={16} /> About Us</li>
                 <li onClick={() => handleNav("/terms")}><FileLock size={16} /> Terms & Conditions</li>
@@ -151,6 +154,7 @@ function AppContent() {
         <Route path="/submit" element={<ProtectedRoute><SubmitHealthData /></ProtectedRoute>} />
         <Route path="/view" element={<ProtectedRoute><ViewHealthData /></ProtectedRoute>} />
         <Route path="/medical-history" element={<ProtectedRoute><MedicalHistory /></ProtectedRoute>} />
+        <Route path="/medication-history" element={<ProtectedRoute><MedicationHistory /></ProtectedRoute>} />
         <Route path="/symptom-checker" element={<ProtectedRoute><SymptomChecker /></ProtectedRoute>} />
         <Route path="/health-chatbot" element={<ProtectedRoute><HealthChatbot /></ProtectedRoute>} />
         <Route path="/note-summarizer" element={<ProtectedRoute><NoteSummarizer /></ProtectedRoute>} />

--- a/src/components/MedicalRecordQR.jsx
+++ b/src/components/MedicalRecordQR.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+// Placeholder QR component. For full functionality, install `qrcode.react`.
+export default function MedicalRecordQR({ data }) {
+  if (!data) return null;
+  return (
+    <pre className="qr-container border p-2">{data}</pre>
+  );
+}

--- a/src/pages/MedicationHistory.jsx
+++ b/src/pages/MedicationHistory.jsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import MedicalRecordQR from '../components/MedicalRecordQR';
+import {
+  AGE_GROUPS,
+  addRecord,
+  getRecords,
+  getGroupJSON,
+  exportGroupToPDF,
+} from '../services/medicalRecordService';
+
+export default function MedicationHistory() {
+  const [form, setForm] = useState({ name: '', dosage: '', date: '', age: '' });
+  const [ageGroup, setAgeGroup] = useState(AGE_GROUPS.adults);
+  const [records, setRecords] = useState([]);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleAdd = (e) => {
+    e.preventDefault();
+    if (!form.name || !form.dosage || !form.date || !form.age) return;
+    const age = parseInt(form.age, 10);
+    let group = AGE_GROUPS.adults;
+    if (age <= 1) group = AGE_GROUPS.infants;
+    else if (age <= 4) group = AGE_GROUPS.toddlers;
+    else if (age <= 17) group = AGE_GROUPS.youth;
+    addRecord(group, { name: form.name, dosage: form.dosage, date: form.date });
+    setAgeGroup(group);
+    setRecords(getRecords(group));
+    setForm({ name: '', dosage: '', date: '', age: '' });
+  };
+
+  const handleLoad = (group) => {
+    setAgeGroup(group);
+    setRecords(getRecords(group));
+  };
+
+  const handlePDF = () => {
+    exportGroupToPDF(ageGroup);
+  };
+
+  const jsonData = getGroupJSON(ageGroup);
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold mb-4">Medication History</h2>
+      <form onSubmit={handleAdd} className="space-y-2">
+        <input name="name" value={form.name} onChange={handleChange} placeholder="Medication Name" className="border p-1" />
+        <input name="dosage" value={form.dosage} onChange={handleChange} placeholder="Dosage" className="border p-1" />
+        <input type="date" name="date" value={form.date} onChange={handleChange} className="border p-1" />
+        <input name="age" value={form.age} onChange={handleChange} placeholder="Age" className="border p-1" />
+        <button type="submit" className="bg-blue-500 text-white px-2 py-1">Add</button>
+      </form>
+
+      <div className="mt-4">
+        <h3 className="font-semibold">Select Age Group</h3>
+        {Object.values(AGE_GROUPS).map((g) => (
+          <button key={g} className="mr-2 underline" onClick={() => handleLoad(g)}>{g}</button>
+        ))}
+      </div>
+
+      <div className="mt-4">
+        <button className="bg-green-500 text-white px-2 py-1" onClick={handlePDF}>Export PDF</button>
+      </div>
+
+      <ul className="mt-4 list-disc list-inside">
+        {records.map((r, idx) => (
+          <li key={idx}>{r.name} - {r.dosage} - {r.date}</li>
+        ))}
+      </ul>
+
+      <div className="mt-4">
+        <MedicalRecordQR data={jsonData} />
+      </div>
+    </div>
+  );
+}

--- a/src/services/medicalRecordService.js
+++ b/src/services/medicalRecordService.js
@@ -1,0 +1,62 @@
+export const AGE_GROUPS = {
+  infants: 'infants',
+  toddlers: 'toddlers',
+  youth: 'youth',
+  adults: 'adults',
+};
+
+const STORAGE_KEY = 'medical_records';
+
+function load() {
+  const data = localStorage.getItem(STORAGE_KEY);
+  if (data) {
+    return JSON.parse(data);
+  }
+  return {
+    [AGE_GROUPS.infants]: [],
+    [AGE_GROUPS.toddlers]: [],
+    [AGE_GROUPS.youth]: [],
+    [AGE_GROUPS.adults]: [],
+  };
+}
+
+function save(records) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(records));
+}
+
+export function addRecord(ageGroup, record) {
+  const records = load();
+  if (!records[ageGroup]) {
+    records[ageGroup] = [];
+  }
+  records[ageGroup].push(record);
+  save(records);
+}
+
+export function getRecords(ageGroup, startDate, endDate) {
+  const records = load()[ageGroup] || [];
+  return records.filter((r) => {
+    const d = new Date(r.date);
+    return (!startDate || d >= new Date(startDate)) && (!endDate || d <= new Date(endDate));
+  });
+}
+
+export function getGroupJSON(ageGroup) {
+  const records = load()[ageGroup] || [];
+  return JSON.stringify(records);
+}
+
+export async function exportGroupToPDF(ageGroup) {
+  try {
+    const { jsPDF } = await import('jspdf');
+    const records = load()[ageGroup] || [];
+    const doc = new jsPDF();
+    doc.text(`Medication History: ${ageGroup}`, 10, 10);
+    records.forEach((r, idx) => {
+      doc.text(`${idx + 1}. ${r.name} - ${r.dosage} - ${r.date}`, 10, 20 + idx * 10);
+    });
+    doc.save(`${ageGroup}-medications.pdf`);
+  } catch (err) {
+    console.error('PDF export failed. Ensure jspdf is installed.', err);
+  }
+}


### PR DESCRIPTION
## Summary
- add postcss config with tailwind and autoprefixer
- introduce medication record service with PDF export helper
- add medication history page with placeholder QR display and navigation updates

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892f95f77b4832d935fc4802a513072